### PR TITLE
Add rescuable special characters for bonus points

### DIFF
--- a/character.py
+++ b/character.py
@@ -1,0 +1,48 @@
+import random
+
+import pygame
+
+import graphics
+
+
+class Character():
+    # Rescuable characters: fly the rocket into one for a bonus.
+    SPRITES = [
+        "assets/sprites/pico-a.svg",
+        "assets/sprites/nano-a.svg",
+        "assets/sprites/giga-a.svg",
+        "assets/sprites/tera-a.svg",
+    ]
+
+    def __init__(self, game):
+        self.game = game
+        self.image = graphics.load_sprite(random.choice(self.SPRITES), scale=0.5)
+        self.width, self.height = self.image.get_size()
+        # Stationary spawn: random spot clear of the HUD band and the screen edges.
+        top_margin = 45  # Keep below the HUD text along the top
+        self.x = random.uniform(0, self.game.DISPLAY_W - self.width)
+        self.y = random.uniform(top_margin, self.game.DISPLAY_H - self.height)
+        self.freq = 400  # Frames between spawns (mirrors asteroid/projectile freq)
+        self.lifespan = 4000  # Milliseconds visible before vanishing if not rescued
+        self.spawn_time = pygame.time.get_ticks()
+        self.reward = 5  # Points earned for rescuing this character
+        self.remove = False
+        self.rect = self.image.get_rect(topleft=(round(self.x), round(self.y)))
+        self.mask = graphics.mask_from(self.image)
+
+    def blit_character(self):  # Displaying character
+        self.rect.topleft = (round(self.x), round(self.y))
+        self.game.display.blit(self.image, self.rect)
+
+    def update_character(self):  # Vanish once its lifespan elapses
+        if pygame.time.get_ticks() - self.spawn_time >= self.lifespan:
+            self.remove = True
+
+    def characters_update(self):
+        for c in self.game.characters[:]:  # Iterate a copy so removals don't skip items
+            c.update_character()
+            if c.remove:  # Expired: gone before it was rescued
+                self.game.characters.remove(c)
+            elif graphics.masks_collide(self.game.rocket, c):  # Rescued by the rocket
+                self.game.characters.remove(c)
+                self.game.score += c.reward

--- a/game.py
+++ b/game.py
@@ -3,6 +3,7 @@ from menu import MainMenu, OptionsMenu, CreditsMenu
 from rocket import Rocket
 from projectile import Projectile
 from asteroid import Asteroid
+from character import Character
 
 
 class Game():
@@ -27,6 +28,8 @@ class Game():
         self.projectiles = []
         self.asteroid = Asteroid(self)
         self.asteroids = []
+        self.character = Character(self)
+        self.characters = []
         self.score = 0  # Points earned by shooting asteroids
         self.high_score_file = 'highscore.txt'  # Best score persisted between sessions
         self.high_score = self.load_high_score()
@@ -34,6 +37,7 @@ class Game():
     def game_loop(self):
         i = 0  # Projectiles loop
         j = 0  # Asteroids loop
+        k = 0  # Characters loop
         while self.playing:
             self.display.fill(self.BLACK)  # Black screen
             self.check_events()
@@ -47,7 +51,11 @@ class Game():
             if j == 0:  # Generate a new asteroid every freq per frame
                 self.asteroids.append(Asteroid(self))
             j = (j + 1) % self.asteroid.freq
+            if k == 0:  # Generate a new character every freq per frame
+                self.characters.append(Character(self))
+            k = (k + 1) % self.character.freq
             self.asteroid.asteroids_update()
+            self.character.characters_update()
             self.projectiles_update()
             self.rocket.move_rocket()
             self.redrawGameWindow()
@@ -109,6 +117,7 @@ class Game():
                     self.score = 0  # Reset score for a fresh game
                     self.projectiles = []
                     self.asteroids = []
+                    self.characters = []
                 if event.key == pygame.K_BACKSPACE:
                     self.BACK_KEY = True
                 if event.key == pygame.K_DOWN:
@@ -163,6 +172,8 @@ class Game():
             p.blit_projectile()
         for a in self.asteroids:  # Draw all the asteroids
             a.blit_asteroid()
+        for c in self.characters:  # Draw all the rescuable characters
+            c.blit_character()
         self.draw_hud()  # Draw the score and lives on top
         self.window.blit(self.display, (0, 0))  # Blitting is drawing
         pygame.display.update()


### PR DESCRIPTION
## Summary

Implements the **"rescue special characters"** feature described in the README. Special characters now appear in the asteroid field; flying the rocket into one rescues it for a **+5** bonus.

## Behavior
- **Reward:** +5 points per rescue (vs. +1 for destroying an asteroid).
- **Immune to projectiles:** only the rocket touching a character rescues it — bolts pass through harmlessly.
- **Timeout:** characters appear stationary and vanish after ~4s if not collected.
- Uses the previously-unused `pico-a`/`nano-a`/`giga-a`/`tera-a` sprites, picked at random per spawn.

## Implementation
- **New `character.py`** — a `Character` entity mirroring the `Asteroid` pattern (sprite/`rect`/`mask`, `blit_character`, `update_character`, `characters_update`). Reuses the shared `graphics` helpers (`load_sprite`, `mask_from`, `masks_collide`) — no new graphics utilities. Timeout uses `pygame.time.get_ticks` so it's framerate-independent.
- **`game.py`** — wired in exactly like asteroids: import, `__init__` fields, a spawn counter + `characters_update()` in `game_loop`, reset on new game, and a draw pass before the HUD. No changes needed to the HUD, menu, or game-over screen — the bonus flows through `self.score` and persists as high score automatically.

## Verification
- Byte-compile clean.
- Headless logic test (SDL dummy driver): spawn within bounds/below HUD, rescue gives +5 and removes the character, projectile overlap leaves it unharmed with score unchanged, expired character removed after its lifespan.
- Rendered a representative frame confirming characters display correctly on-screen.

Tunables in `character.py` if you want it livelier: `freq` (spawn cadence) and `lifespan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)